### PR TITLE
Fix MAX17048 GND Direction

### DIFF
--- a/Symbols/SparkFun-IC-Power.kicad_sym
+++ b/Symbols/SparkFun-IC-Power.kicad_sym
@@ -1405,7 +1405,7 @@
 					)
 				)
 			)
-			(pin power_out line
+			(pin power_in line
 				(at 0 -8.89 90)
 				(length 2.54) hide
 				(name "GND"


### PR DESCRIPTION
Was set as Power Output, resulting in ERC error. Should be Power Input