### PR TITLE
Set SOT-583-8 thermal spoke angle to 0

### DIFF
--- a/Footprints/SparkFun-Semiconductor-Standard.pretty/SOT-583-8.kicad_mod
+++ b/Footprints/SparkFun-Semiconductor-Standard.pretty/SOT-583-8.kicad_mod
@@ -196,7 +196,7 @@
 		(size 0.67 0.3)
 		(layers "F.Cu" "F.Paste" "F.Mask")
 		(roundrect_rratio 0.1666666667)
-		(thermal_bridge_angle 45)
+		(thermal_bridge_angle 0)
 		(uuid "95a914b1-aec2-459c-800f-527932fedd92")
 	)
 	(pad "2" smd roundrect
@@ -204,7 +204,7 @@
 		(size 0.67 0.3)
 		(layers "F.Cu" "F.Paste" "F.Mask")
 		(roundrect_rratio 0.1666666667)
-		(thermal_bridge_angle 45)
+		(thermal_bridge_angle 0)
 		(uuid "5de94aae-9906-4965-9618-f00742a4da1b")
 	)
 	(pad "3" smd roundrect
@@ -212,7 +212,7 @@
 		(size 0.67 0.3)
 		(layers "F.Cu" "F.Paste" "F.Mask")
 		(roundrect_rratio 0.1666666667)
-		(thermal_bridge_angle 45)
+		(thermal_bridge_angle 0)
 		(uuid "b826fa82-10f0-4667-af3a-1adde81a4e08")
 	)
 	(pad "4" smd roundrect
@@ -220,7 +220,7 @@
 		(size 0.67 0.3)
 		(layers "F.Cu" "F.Paste" "F.Mask")
 		(roundrect_rratio 0.1666666667)
-		(thermal_bridge_angle 45)
+		(thermal_bridge_angle 0)
 		(uuid "32de9d04-c646-4004-ad6f-5e9c48bf5b78")
 	)
 	(pad "5" smd roundrect
@@ -228,7 +228,7 @@
 		(size 0.67 0.3)
 		(layers "F.Cu" "F.Paste" "F.Mask")
 		(roundrect_rratio 0.1666666667)
-		(thermal_bridge_angle 45)
+		(thermal_bridge_angle 0)
 		(uuid "799b8374-eccb-4cb4-ab0d-3eb9624f4353")
 	)
 	(pad "6" smd roundrect
@@ -236,7 +236,7 @@
 		(size 0.67 0.3)
 		(layers "F.Cu" "F.Paste" "F.Mask")
 		(roundrect_rratio 0.1666666667)
-		(thermal_bridge_angle 45)
+		(thermal_bridge_angle 0)
 		(uuid "45369f82-2854-4cab-875a-dfaa3dfabcac")
 	)
 	(pad "7" smd roundrect
@@ -244,7 +244,7 @@
 		(size 0.67 0.3)
 		(layers "F.Cu" "F.Paste" "F.Mask")
 		(roundrect_rratio 0.1666666667)
-		(thermal_bridge_angle 45)
+		(thermal_bridge_angle 0)
 		(uuid "e6ea1b52-1b23-422b-8067-e20bb830ab5e")
 	)
 	(pad "8" smd roundrect
@@ -252,7 +252,7 @@
 		(size 0.67 0.3)
 		(layers "F.Cu" "F.Paste" "F.Mask")
 		(roundrect_rratio 0.1666666667)
-		(thermal_bridge_angle 45)
+		(thermal_bridge_angle 0)
 		(uuid "c44da805-c063-4a08-bb9b-74907d6e2e33")
 	)
 	(model "${SPARKFUN_KICAD_LIBRARY}/Footprints/SparkFun-3D-models/Semiconductor-Standard/SOT-583-3.stp"


### PR DESCRIPTION
For some reason, the spokes are currently set to 45 degrees:

![image](https://github.com/user-attachments/assets/e949244e-0052-4014-b4fa-268cb72ca648)

Proposing it gets set to 0 degrees:

![image](https://github.com/user-attachments/assets/ca8c3af9-80ba-42b4-ad83-1ab4ecb36bc3)
