### PR TITLE
Updates on RPI passthrough headers

### DIFF
--- a/Footprints/SparkFun-Connector.pretty/Raspberry_Pi_Shield_Bottom_Entry_No_Mounting_Holes.kicad_mod
+++ b/Footprints/SparkFun-Connector.pretty/Raspberry_Pi_Shield_Bottom_Entry_No_Mounting_Holes.kicad_mod
@@ -508,8 +508,8 @@
 		(uuid "95d1b138-4f15-4857-ab9c-8e77d2d71e0c")
 	)
 	(fp_circle
-		(center 3.3298 -25.25)
-		(end 3.3298 -25.138197)
+		(center -3.3298 -25.25)
+		(end -3.217997 -25.25)
 		(stroke
 			(width 0.254)
 			(type solid)

--- a/Symbols/SparkFun-Connector.kicad_sym
+++ b/Symbols/SparkFun-Connector.kicad_sym
@@ -53057,7 +53057,7 @@
 				(hide yes)
 			)
 		)
-		(property "Datasheet" "https://cdn.harwin.com/pdfs/M20-781.pdf"
+		(property "Datasheet" "http://www.4uconnector.com/online/object/4udrawing/10956.pdf"
 			(at 0 -35.56 0)
 			(effects
 				(font
@@ -53075,7 +53075,7 @@
 				(hide yes)
 			)
 		)
-		(property "PROD_ID" "CONN-24972"
+		(property "PROD_ID" "CONN-13790"
 			(at 0 -43.18 0)
 			(effects
 				(font
@@ -53869,7 +53869,7 @@
 				(hide yes)
 			)
 		)
-		(property "Datasheet" "https://cdn.harwin.com/pdfs/M20-781.pdf"
+		(property "Datasheet" "http://www.4uconnector.com/online/object/4udrawing/10956.pdf"
 			(at 0 -35.56 0)
 			(effects
 				(font
@@ -53887,7 +53887,7 @@
 				(hide yes)
 			)
 		)
-		(property "PROD_ID" "CONN-24972"
+		(property "PROD_ID" "CONN-13790"
 			(at 0 -43.18 0)
 			(effects
 				(font


### PR DESCRIPTION
* Change RPi passthrough header PROD_ID to CONN-13790
    * CONN-13790 is 4UConn 10956 - without pegs
    * CONN-24972 is Harwin 952-M20-7812045RCT-ND - with pegs
    * Footprints can accept either - they have the peg holes
* Correct position of the Pin 1 marker on the passthrough bottom-entry footprint
    * The pad numbering and positions are correct. The pin 1 marker was actually marking pin 2