### PR TITLE
VEML7700 minor fix

### DIFF
--- a/Symbols/SparkFun-Sensor.kicad_sym
+++ b/Symbols/SparkFun-Sensor.kicad_sym
@@ -3810,14 +3810,14 @@
 				(name "VDD"
 					(effects
 						(font
-							(size 1.524 1.524)
+							(size 1.27 1.27)
 						)
 					)
 				)
 				(number "2"
 					(effects
 						(font
-							(size 0 0)
+							(size 1.27 1.27)
 						)
 					)
 				)
@@ -3828,14 +3828,14 @@
 				(name "GND"
 					(effects
 						(font
-							(size 1.524 1.524)
+							(size 1.27 1.27)
 						)
 					)
 				)
 				(number "3"
 					(effects
 						(font
-							(size 0 0)
+							(size 1.27 1.27)
 						)
 					)
 				)
@@ -3846,14 +3846,14 @@
 				(name "SDA"
 					(effects
 						(font
-							(size 1.524 1.524)
+							(size 1.27 1.27)
 						)
 					)
 				)
 				(number "4"
 					(effects
 						(font
-							(size 0 0)
+							(size 1.27 1.27)
 						)
 					)
 				)
@@ -3864,14 +3864,14 @@
 				(name "SCL"
 					(effects
 						(font
-							(size 1.524 1.524)
+							(size 1.27 1.27)
 						)
 					)
 				)
 				(number "1"
 					(effects
 						(font
-							(size 0 0)
+							(size 1.27 1.27)
 						)
 					)
 				)


### PR DESCRIPTION
Show "pin name" was set to "on" in the symbol but the size of the text was set to zero - probably an oddity with importing it in from Eagle. This has been fixed. 