### PR TITLE
Fixes path to the footprint for the LIS3DH

### DIFF
--- a/Symbols/SparkFun-Sensor.kicad_sym
+++ b/Symbols/SparkFun-Sensor.kicad_sym
@@ -729,7 +729,7 @@
 				(justify left top)
 			)
 		)
-		(property "Footprint" "SparkFun-Semiconductor-Nonstandard:ST_LGA-16_3x3mm_P0.5mm_5x3"
+		(property "Footprint" "SparkFun-Sensor:ST_LGA-16_3x3mm_P0.5mm_5x3"
 			(at -0.762 -23.368 0)
 			(effects
 				(font


### PR DESCRIPTION
The footprint for the LIS3DH was in a different sub-folder than the one listed in they symbol. I've moved it to point at the correct one. 