### PR TITLE
Relinks 1x01_PTH_1x1mm to it's footprint

### DIFF
--- a/Symbols/SparkFun-Connector.kicad_sym
+++ b/Symbols/SparkFun-Connector.kicad_sym
@@ -1738,7 +1738,7 @@
 				)
 			)
 		)
-		(property "Footprint" "SparkFun-Connector:1x01_PTH_1x1mm"
+		(property "Footprint" "SparkFun-Connector:1x01_1x1mm"
 			(at 0 -7.62 0)
 			(effects
 				(font


### PR DESCRIPTION
Relinks the symbol to the footprint after the footprint was renamed. 