### PR TITLE
Fix MX25UW12845G symbol datasheet

### DIFF
--- a/symbols/SparkFun-IC-Memory.kicad_sym
+++ b/symbols/SparkFun-IC-Memory.kicad_sym
@@ -2163,7 +2163,7 @@
 				)
 			)
 		)
-		(property "Datasheet" "https://www.macronix.com/Lists/Datasheet/Attachments/9106/MX25U12845G,%201.8V,%20128Mb,%20v1.0.pdf"
+		(property "Datasheet" "https://datasheet.lcsc.com/datasheet/pdf/d723edbd162fb64eed35787ccee2750a.pdf?productCode=C20099950"
 			(at 0 -21.59 0)
 			(show_name no)
 			(do_not_autoplace no)


### PR DESCRIPTION
Was incorrectly using datasheet for MX25U12845G (no **W**, quad IO chip instead of octal)