### PR TITLE
Fix LBEE5KL1YN

### DIFF
--- a/footprints/SparkFun-RF.pretty/LBEE5KL1YN.kicad_mod
+++ b/footprints/SparkFun-RF.pretty/LBEE5KL1YN.kicad_mod
@@ -7,7 +7,7 @@
 	(property "Reference" "REF**"
 		(at 0 -3 180)
 		(layer "F.Fab")
-		(uuid "86007fb1-d5b5-4cf3-ab66-857924d79905")
+		(uuid "27996a26-623a-4d0c-a800-a57dffa20766")
 		(effects
 			(font
 				(size 0.5 0.5)
@@ -20,7 +20,7 @@
 	(property "Value" "LBEE5KL1YN"
 		(at 0 3 180)
 		(layer "F.Fab")
-		(uuid "298d6a91-29f8-48bc-93b1-a63609dfc3dd")
+		(uuid "a2a9dacf-bc75-485c-9431-cf0d98b86f0a")
 		(effects
 			(font
 				(size 0.5 0.5)
@@ -35,7 +35,7 @@
 		(unlocked yes)
 		(layer "F.Fab")
 		(hide yes)
-		(uuid "b2e950b1-b304-43cf-ad28-a38d4e8c3dfc")
+		(uuid "d9a40113-5782-4df9-bc1a-128dada66222")
 		(effects
 			(font
 				(size 1.27 1.27)
@@ -48,7 +48,7 @@
 		(unlocked yes)
 		(layer "F.Fab")
 		(hide yes)
-		(uuid "1dd6be24-48c7-460d-9080-5da036b7d723")
+		(uuid "dbc8445f-488b-4d54-bcbe-8a8b22edf20d")
 		(effects
 			(font
 				(size 1.27 1.27)
@@ -66,7 +66,7 @@
 			(type solid)
 		)
 		(layer "F.SilkS")
-		(uuid "e1edaad4-7224-484e-aae4-6d3cf8101fc1")
+		(uuid "1f38ea54-22eb-41fb-bcdd-9aaa7ccf5218")
 	)
 	(fp_line
 		(start -3.675 1.775)
@@ -76,7 +76,7 @@
 			(type solid)
 		)
 		(layer "F.SilkS")
-		(uuid "9fcd032c-3280-4f20-8f63-a92c5ee13164")
+		(uuid "a41594c4-a6ac-4292-af2c-45ed67228623")
 	)
 	(fp_line
 		(start -3.675 2.775)
@@ -86,7 +86,7 @@
 			(type solid)
 		)
 		(layer "F.SilkS")
-		(uuid "77cf3844-1f85-449f-8c95-882658465c0f")
+		(uuid "3877e9c2-6262-485a-84a8-af7a01582596")
 	)
 	(fp_line
 		(start -2.675 -2.775)
@@ -96,7 +96,7 @@
 			(type solid)
 		)
 		(layer "F.SilkS")
-		(uuid "9e1ca155-eeef-4698-b731-a4c26fea91a2")
+		(uuid "7ff983f0-658b-4a67-aa20-f826bcc33b96")
 	)
 	(fp_line
 		(start 2.675 -2.775)
@@ -106,7 +106,7 @@
 			(type solid)
 		)
 		(layer "F.SilkS")
-		(uuid "22a3461b-f102-400a-b467-16b8a23bc2ad")
+		(uuid "9ec5da08-cb82-4c9a-bdc7-5e69701262b0")
 	)
 	(fp_line
 		(start 2.675 2.775)
@@ -116,7 +116,7 @@
 			(type solid)
 		)
 		(layer "F.SilkS")
-		(uuid "b5326772-f535-4cd3-aa10-0a8ea5e9047b")
+		(uuid "4194faa7-a964-4c11-b705-9bfa55146f89")
 	)
 	(fp_line
 		(start 3.675 -1.775)
@@ -126,7 +126,7 @@
 			(type solid)
 		)
 		(layer "F.SilkS")
-		(uuid "7e9ae75e-853c-4d88-a72b-bd218ade509a")
+		(uuid "c9c33e03-8be6-4549-9552-ecb62668b3e6")
 	)
 	(fp_line
 		(start 3.675 2.775)
@@ -136,18 +136,18 @@
 			(type solid)
 		)
 		(layer "F.SilkS")
-		(uuid "a6dd8c59-319b-4686-9261-74ebc96bcc23")
+		(uuid "1c0fff9e-d9f1-45ed-9ad6-c9167ca3e4aa")
 	)
 	(fp_circle
-		(center -2.25 3)
-		(end -2.1 3)
+		(center -3 3.25)
+		(end -2.9 3.25)
 		(stroke
-			(width 0.3)
+			(width 0.2)
 			(type solid)
 		)
 		(fill yes)
 		(layer "F.SilkS")
-		(uuid "ab4b5076-1d76-4b6e-878b-6e30528c15bc")
+		(uuid "04cb0d79-283c-4913-b3b8-286fcd56f409")
 	)
 	(fp_rect
 		(start -3.675 -2.775)
@@ -158,7 +158,7 @@
 		)
 		(fill no)
 		(layer "F.CrtYd")
-		(uuid "2e34d15f-52b2-4647-bcbd-9a73a8f38802")
+		(uuid "41e6a0f0-e48c-41a8-bee8-cb902bf18e4b")
 	)
 	(fp_rect
 		(start -3.475 -2.575)
@@ -169,7 +169,7 @@
 		)
 		(fill no)
 		(layer "F.Fab")
-		(uuid "25cbe8a8-4602-447e-a4c2-a15799e73b4a")
+		(uuid "1187d487-a412-442a-9172-dd1657d31b6f")
 	)
 	(pad "1" smd rect
 		(at -2.25 2.025)
@@ -177,7 +177,7 @@
 		(layers "F.Cu" "F.Mask" "F.Paste")
 		(solder_paste_margin -0.025)
 		(thermal_bridge_angle 0)
-		(uuid "4cd3504a-8ebf-47e9-8634-90812dea547b")
+		(uuid "6b1e8521-9370-4d40-988e-57fa9a7b487f")
 	)
 	(pad "2" smd rect
 		(at -1.8 2.025)
@@ -185,7 +185,7 @@
 		(layers "F.Cu" "F.Mask" "F.Paste")
 		(solder_paste_margin -0.025)
 		(thermal_bridge_angle 0)
-		(uuid "36562f8a-77ba-44c4-a644-a65bd952db8a")
+		(uuid "c7906ff1-9876-4ab8-bb29-15b00b484540")
 	)
 	(pad "3" smd rect
 		(at -1.35 2.025)
@@ -193,7 +193,7 @@
 		(layers "F.Cu" "F.Mask" "F.Paste")
 		(solder_paste_margin -0.025)
 		(thermal_bridge_angle 0)
-		(uuid "c3971fcc-cdf2-4cf3-92dc-06f3526a25b2")
+		(uuid "23e9d9a2-addf-43f9-9884-e4b3b5117f39")
 	)
 	(pad "4" smd rect
 		(at -0.9 2.025)
@@ -201,7 +201,7 @@
 		(layers "F.Cu" "F.Mask" "F.Paste")
 		(solder_paste_margin -0.025)
 		(thermal_bridge_angle 0)
-		(uuid "33187a86-0285-4489-a0b0-7d42ee8ed7f8")
+		(uuid "858b3881-8912-49e1-8f50-d1b8007f9f52")
 	)
 	(pad "5" smd rect
 		(at -0.45 2.025)
@@ -209,7 +209,7 @@
 		(layers "F.Cu" "F.Mask" "F.Paste")
 		(solder_paste_margin -0.025)
 		(thermal_bridge_angle 0)
-		(uuid "eceabdc1-959c-4c99-bcea-327b78b33d9d")
+		(uuid "61b4214d-07be-495e-9ad6-598bbb1b1d39")
 	)
 	(pad "6" smd rect
 		(at 0 2.025)
@@ -217,7 +217,7 @@
 		(layers "F.Cu" "F.Mask" "F.Paste")
 		(solder_paste_margin -0.025)
 		(thermal_bridge_angle 0)
-		(uuid "e06472cc-8f3b-4ae0-b697-910b638f59cc")
+		(uuid "034102bc-56ea-4baa-9166-5e826168dda1")
 	)
 	(pad "7" smd rect
 		(at 0.45 2.025)
@@ -225,7 +225,7 @@
 		(layers "F.Cu" "F.Mask" "F.Paste")
 		(solder_paste_margin -0.025)
 		(thermal_bridge_angle 0)
-		(uuid "2a500725-82a9-4551-8c8a-5ab365e50e26")
+		(uuid "e11ffa31-c9ff-4685-a700-6921ecf96963")
 	)
 	(pad "8" smd rect
 		(at 0.9 2.025)
@@ -233,7 +233,7 @@
 		(layers "F.Cu" "F.Mask" "F.Paste")
 		(solder_paste_margin -0.025)
 		(thermal_bridge_angle 0)
-		(uuid "7a78aaa7-ee05-4091-857e-33cd5627d5aa")
+		(uuid "567be674-1ad2-4433-8fe1-cb7b3f79f4f7")
 	)
 	(pad "9" smd rect
 		(at 1.35 2.025)
@@ -241,7 +241,7 @@
 		(layers "F.Cu" "F.Mask" "F.Paste")
 		(solder_paste_margin -0.025)
 		(thermal_bridge_angle 0)
-		(uuid "befefdd8-3800-468e-a7be-136f53ed9303")
+		(uuid "e8a28b81-ef5e-48db-a716-6c757ae46c5e")
 	)
 	(pad "10" smd rect
 		(at 1.8 2.025)
@@ -249,7 +249,7 @@
 		(layers "F.Cu" "F.Mask" "F.Paste")
 		(solder_paste_margin -0.025)
 		(thermal_bridge_angle 0)
-		(uuid "5bbf30a2-9c11-4362-8f66-9a90c81b28e3")
+		(uuid "4df2de47-08bf-48bc-a670-349a21961b03")
 	)
 	(pad "11" smd rect
 		(at 2.25 2.025)
@@ -257,7 +257,7 @@
 		(layers "F.Cu" "F.Mask" "F.Paste")
 		(solder_paste_margin -0.025)
 		(thermal_bridge_angle 0)
-		(uuid "8d465888-01fe-4020-9904-5f832215dc88")
+		(uuid "e8cafa8a-8e9a-407a-a177-16ef4919535d")
 	)
 	(pad "12" smd rect
 		(at 2.925 2.0875)
@@ -265,7 +265,7 @@
 		(layers "F.Cu" "F.Mask" "F.Paste")
 		(solder_paste_margin -0.025)
 		(thermal_bridge_angle 0)
-		(uuid "30144d93-c745-4091-913a-22e6aeec33be")
+		(uuid "f5521eb5-78c5-427b-a40a-914aed20521e")
 	)
 	(pad "13" smd rect
 		(at 2.925 1.575 90)
@@ -273,7 +273,7 @@
 		(layers "F.Cu" "F.Mask" "F.Paste")
 		(solder_paste_margin -0.025)
 		(thermal_bridge_angle 0)
-		(uuid "64799328-f356-43d2-acad-b09f26545714")
+		(uuid "20c8f5d2-c140-425c-9411-72c5b22a2ca6")
 	)
 	(pad "14" smd rect
 		(at 2.925 1.125 90)
@@ -281,7 +281,7 @@
 		(layers "F.Cu" "F.Mask" "F.Paste")
 		(solder_paste_margin -0.025)
 		(thermal_bridge_angle 0)
-		(uuid "01075f5f-07d9-45cd-ae06-ce74f5a552d6")
+		(uuid "d1338015-89b2-43a0-af99-ba5bb8c63bc7")
 	)
 	(pad "15" smd rect
 		(at 2.925 0.675 90)
@@ -289,7 +289,7 @@
 		(layers "F.Cu" "F.Mask" "F.Paste")
 		(solder_paste_margin -0.025)
 		(thermal_bridge_angle 0)
-		(uuid "68e5ab9b-ef9e-4bdd-aa91-f7297e5bf6d1")
+		(uuid "6d483985-57a4-4a27-9417-2a32b9c89a4e")
 	)
 	(pad "16" smd rect
 		(at 2.925 0.225 90)
@@ -297,7 +297,7 @@
 		(layers "F.Cu" "F.Mask" "F.Paste")
 		(solder_paste_margin -0.025)
 		(thermal_bridge_angle 0)
-		(uuid "578b82b5-1c74-45bc-8fdd-2357131026f6")
+		(uuid "cf462eb4-8fb1-43da-b958-6cfa1464db20")
 	)
 	(pad "17" smd rect
 		(at 2.925 -0.225 90)
@@ -305,7 +305,7 @@
 		(layers "F.Cu" "F.Mask" "F.Paste")
 		(solder_paste_margin -0.025)
 		(thermal_bridge_angle 0)
-		(uuid "6df1e1ea-b8fb-4a63-a9da-37e579d738c2")
+		(uuid "ed3cca34-e419-4c59-b95f-06b011b33e69")
 	)
 	(pad "18" smd rect
 		(at 2.925 -0.675 90)
@@ -313,7 +313,7 @@
 		(layers "F.Cu" "F.Mask" "F.Paste")
 		(solder_paste_margin -0.025)
 		(thermal_bridge_angle 0)
-		(uuid "a5cf8e08-70f1-49e5-a798-122b8c6f97a1")
+		(uuid "fd063f89-5b0f-4d43-9c76-2d6eea8df473")
 	)
 	(pad "19" smd rect
 		(at 2.925 -1.125 90)
@@ -321,7 +321,7 @@
 		(layers "F.Cu" "F.Mask" "F.Paste")
 		(solder_paste_margin -0.025)
 		(thermal_bridge_angle 0)
-		(uuid "871a7b9d-9b93-4e1b-8e3e-5f6444e1c460")
+		(uuid "78dae861-d856-454c-ba09-f8be939ec36d")
 	)
 	(pad "20" smd rect
 		(at 2.925 -1.575 90)
@@ -329,7 +329,7 @@
 		(layers "F.Cu" "F.Mask" "F.Paste")
 		(solder_paste_margin -0.025)
 		(thermal_bridge_angle 0)
-		(uuid "4bee736a-ccd7-4e5d-96b8-36e8e9585b98")
+		(uuid "a885d327-9694-464e-83f3-f5917921ae1e")
 	)
 	(pad "21" smd rect
 		(at 2.925 -2.0875)
@@ -337,7 +337,7 @@
 		(layers "F.Cu" "F.Mask" "F.Paste")
 		(solder_paste_margin -0.025)
 		(thermal_bridge_angle 0)
-		(uuid "df20b92b-612b-49ca-b207-4c8998e1f0e4")
+		(uuid "07c05d0b-a38b-462d-95ba-3b975d54514f")
 	)
 	(pad "22" smd rect
 		(at 2.25 -2.025)
@@ -345,7 +345,7 @@
 		(layers "F.Cu" "F.Mask" "F.Paste")
 		(solder_paste_margin -0.025)
 		(thermal_bridge_angle 0)
-		(uuid "bf205069-4035-4660-a2de-2e51e36f86d1")
+		(uuid "d23c372b-791d-469b-bc07-d123fd94e355")
 	)
 	(pad "23" smd rect
 		(at 1.8 -2.025)
@@ -353,7 +353,7 @@
 		(layers "F.Cu" "F.Mask" "F.Paste")
 		(solder_paste_margin -0.025)
 		(thermal_bridge_angle 0)
-		(uuid "e5b792ed-2cce-471d-80ce-c29554ee3014")
+		(uuid "c317e856-74c3-41d4-bb42-5fc32c3f7fad")
 	)
 	(pad "24" smd rect
 		(at 1.35 -2.025)
@@ -361,7 +361,7 @@
 		(layers "F.Cu" "F.Mask" "F.Paste")
 		(solder_paste_margin -0.025)
 		(thermal_bridge_angle 0)
-		(uuid "8b2ac92a-65e3-431f-9b2a-bf7ab4e443b7")
+		(uuid "e3f572dc-fff9-46da-b79a-6e8b174752ca")
 	)
 	(pad "25" smd rect
 		(at 0.9 -2.025)
@@ -369,7 +369,7 @@
 		(layers "F.Cu" "F.Mask" "F.Paste")
 		(solder_paste_margin -0.025)
 		(thermal_bridge_angle 0)
-		(uuid "2b725cca-ff07-4e6c-a578-34cbc022ca7f")
+		(uuid "7ad034ea-b84a-4bcd-926e-490531316c5f")
 	)
 	(pad "26" smd rect
 		(at 0.45 -2.025)
@@ -377,7 +377,7 @@
 		(layers "F.Cu" "F.Mask" "F.Paste")
 		(solder_paste_margin -0.025)
 		(thermal_bridge_angle 0)
-		(uuid "95229ff3-6ca7-4482-b775-b316acbb0426")
+		(uuid "06364576-713b-47c1-95a7-0fe59b6eb8f7")
 	)
 	(pad "27" smd rect
 		(at 0 -2.025)
@@ -385,7 +385,7 @@
 		(layers "F.Cu" "F.Mask" "F.Paste")
 		(solder_paste_margin -0.025)
 		(thermal_bridge_angle 0)
-		(uuid "d1c1e4b3-52f0-46f1-9b19-73b43ca472c5")
+		(uuid "3dd0e8c4-a10e-48c9-bb9a-81b74da2f194")
 	)
 	(pad "28" smd rect
 		(at -0.45 -2.025)
@@ -393,7 +393,7 @@
 		(layers "F.Cu" "F.Mask" "F.Paste")
 		(solder_paste_margin -0.025)
 		(thermal_bridge_angle 0)
-		(uuid "9a8c2700-ba43-4365-b177-7ed25f73ee1d")
+		(uuid "808c41ac-c866-470a-8c6b-b89b8886591b")
 	)
 	(pad "29" smd rect
 		(at -0.9 -2.025)
@@ -401,7 +401,7 @@
 		(layers "F.Cu" "F.Mask" "F.Paste")
 		(solder_paste_margin -0.025)
 		(thermal_bridge_angle 0)
-		(uuid "af0997f3-0502-4406-aae5-68b17064fd53")
+		(uuid "8f79863c-ea99-4c8d-a337-4967541ceffe")
 	)
 	(pad "30" smd rect
 		(at -1.35 -2.025)
@@ -409,7 +409,7 @@
 		(layers "F.Cu" "F.Mask" "F.Paste")
 		(solder_paste_margin -0.025)
 		(thermal_bridge_angle 0)
-		(uuid "8230a63c-e1b9-41e1-a2ac-02cb6ffdf07c")
+		(uuid "88e584ae-4533-4755-a964-2207d72f53df")
 	)
 	(pad "31" smd rect
 		(at -1.8 -2.025)
@@ -417,7 +417,7 @@
 		(layers "F.Cu" "F.Mask" "F.Paste")
 		(solder_paste_margin -0.025)
 		(thermal_bridge_angle 0)
-		(uuid "8e6ad653-bff5-461c-b128-928a8fbb04cd")
+		(uuid "2586b669-53b3-42e2-b9a9-59c8973faeaf")
 	)
 	(pad "32" smd rect
 		(at -2.25 -2.025)
@@ -425,7 +425,7 @@
 		(layers "F.Cu" "F.Mask" "F.Paste")
 		(solder_paste_margin -0.025)
 		(thermal_bridge_angle 0)
-		(uuid "887870cc-da19-4810-97ec-af9eea80c2a5")
+		(uuid "145b527e-9923-437d-862b-f4845c39352d")
 	)
 	(pad "33" smd rect
 		(at -2.925 -2.0875)
@@ -433,7 +433,7 @@
 		(layers "F.Cu" "F.Mask" "F.Paste")
 		(solder_paste_margin -0.025)
 		(thermal_bridge_angle 0)
-		(uuid "15759014-6d5c-4180-8d3e-62ee72cd4563")
+		(uuid "e3538395-d0c8-436d-bb07-a48c70e3bde4")
 	)
 	(pad "34" smd rect
 		(at -2.925 -1.575 90)
@@ -441,7 +441,7 @@
 		(layers "F.Cu" "F.Mask" "F.Paste")
 		(solder_paste_margin -0.025)
 		(thermal_bridge_angle 0)
-		(uuid "9a6bde05-8d04-40ed-82e6-fb84afad2408")
+		(uuid "12002a49-0a27-4f58-a505-140e09fbaf97")
 	)
 	(pad "35" smd rect
 		(at -2.925 -1.125 90)
@@ -449,7 +449,7 @@
 		(layers "F.Cu" "F.Mask" "F.Paste")
 		(solder_paste_margin -0.025)
 		(thermal_bridge_angle 0)
-		(uuid "fa36117c-2771-4b9f-b4d8-5d0ccf0fa72d")
+		(uuid "9491e0b3-c754-4cce-a4ca-25ea2a642fa4")
 	)
 	(pad "36" smd rect
 		(at -2.925 -0.675 90)
@@ -457,7 +457,7 @@
 		(layers "F.Cu" "F.Mask" "F.Paste")
 		(solder_paste_margin -0.025)
 		(thermal_bridge_angle 0)
-		(uuid "262eb3b3-6984-4787-bf92-50418a71313d")
+		(uuid "9b9dae87-b111-4ec0-8472-5198a3e4dc7c")
 	)
 	(pad "37" smd rect
 		(at -2.925 -0.225 90)
@@ -465,7 +465,7 @@
 		(layers "F.Cu" "F.Mask" "F.Paste")
 		(solder_paste_margin -0.025)
 		(thermal_bridge_angle 0)
-		(uuid "09eb3606-994f-43e6-8cc0-12580f382115")
+		(uuid "6bfbf339-4ebd-4be8-a779-fcff3281d92e")
 	)
 	(pad "38" smd rect
 		(at -2.925 0.225 90)
@@ -473,7 +473,7 @@
 		(layers "F.Cu" "F.Mask" "F.Paste")
 		(solder_paste_margin -0.025)
 		(thermal_bridge_angle 0)
-		(uuid "d2a0d698-c1f2-4863-8fcb-c9e801c296c8")
+		(uuid "2a1fb9b2-3c86-4661-9573-e801dd4cd138")
 	)
 	(pad "39" smd rect
 		(at -2.925 0.675 90)
@@ -481,7 +481,7 @@
 		(layers "F.Cu" "F.Mask" "F.Paste")
 		(solder_paste_margin -0.025)
 		(thermal_bridge_angle 0)
-		(uuid "7b372e40-0ed4-43bb-abe5-b2a15ab62c4d")
+		(uuid "38608e4a-1a7e-4d21-8497-78b8377b0e42")
 	)
 	(pad "40" smd rect
 		(at -2.925 1.125 90)
@@ -489,7 +489,7 @@
 		(layers "F.Cu" "F.Mask" "F.Paste")
 		(solder_paste_margin -0.025)
 		(thermal_bridge_angle 0)
-		(uuid "b8e51f05-6472-49e6-95fe-d7f5c2e63a62")
+		(uuid "d1875140-3c62-4ac7-8331-b424ba7d368e")
 	)
 	(pad "41" smd rect
 		(at -2.925 1.575 90)
@@ -497,7 +497,7 @@
 		(layers "F.Cu" "F.Mask" "F.Paste")
 		(solder_paste_margin -0.025)
 		(thermal_bridge_angle 0)
-		(uuid "28f2b700-b822-46e9-a8b9-1e8b6809e94e")
+		(uuid "322c2286-eee0-494e-bf87-6fe804eb7965")
 	)
 	(pad "42" smd rect
 		(at -2.925 2.0875)
@@ -505,7 +505,7 @@
 		(layers "F.Cu" "F.Mask" "F.Paste")
 		(solder_paste_margin -0.025)
 		(thermal_bridge_angle 0)
-		(uuid "73256240-4075-4d63-8c19-bbe4b011e85c")
+		(uuid "a2d15454-64ac-4a05-8b92-9444ce271e53")
 	)
 	(pad "43" smd roundrect
 		(at -1 0.75)
@@ -516,7 +516,7 @@
 		(chamfer bottom_left)
 		(solder_paste_margin -0.1)
 		(thermal_bridge_angle 0)
-		(uuid "a82fa997-f3e0-4920-81b9-79c61aa8e732")
+		(uuid "5c36f4be-f7ed-433d-bdae-30ada76c17ce")
 	)
 	(pad "44" smd rect
 		(at 1 0.75)
@@ -524,7 +524,7 @@
 		(layers "F.Cu" "F.Mask" "F.Paste")
 		(solder_paste_margin -0.1)
 		(thermal_bridge_angle 0)
-		(uuid "6ad0f63e-f853-401d-95b6-3bad868ca12e")
+		(uuid "7b67065e-ac64-4034-a854-cfc29e0da4f2")
 	)
 	(pad "45" smd rect
 		(at -1 -0.75)
@@ -532,7 +532,7 @@
 		(layers "F.Cu" "F.Mask" "F.Paste")
 		(solder_paste_margin -0.1)
 		(thermal_bridge_angle 0)
-		(uuid "fd800956-fdc5-474f-bc43-ae7f69b56b50")
+		(uuid "b5f80800-e5bc-4418-a83f-c3b5751a69e3")
 	)
 	(pad "46" smd rect
 		(at 1 -0.75)
@@ -540,7 +540,7 @@
 		(layers "F.Cu" "F.Mask" "F.Paste")
 		(solder_paste_margin -0.1)
 		(thermal_bridge_angle 0)
-		(uuid "36f47342-0f51-4612-92a9-7c2e901ca42d")
+		(uuid "a9740229-4c89-4fd7-b378-7042efde0dec")
 	)
 	(embedded_fonts no)
 	(model "${SPARKFUN_KICAD_LIBRARY}/3dmodels/RF.3dshapes/LBEE5KL1YN.step"

--- a/footprints/SparkFun-RF.pretty/LBEE5KL1YN.kicad_mod
+++ b/footprints/SparkFun-RF.pretty/LBEE5KL1YN.kicad_mod
@@ -7,7 +7,7 @@
 	(property "Reference" "REF**"
 		(at 0 -3 180)
 		(layer "F.Fab")
-		(uuid "d1c4059f-399d-4169-899b-450a20712434")
+		(uuid "86007fb1-d5b5-4cf3-ab66-857924d79905")
 		(effects
 			(font
 				(size 0.5 0.5)
@@ -20,7 +20,7 @@
 	(property "Value" "LBEE5KL1YN"
 		(at 0 3 180)
 		(layer "F.Fab")
-		(uuid "4279bd73-e1d6-45c8-ab25-44e91669d34e")
+		(uuid "298d6a91-29f8-48bc-93b1-a63609dfc3dd")
 		(effects
 			(font
 				(size 0.5 0.5)
@@ -35,7 +35,7 @@
 		(unlocked yes)
 		(layer "F.Fab")
 		(hide yes)
-		(uuid "767182b7-1128-4db2-8ae0-4541d92f0671")
+		(uuid "b2e950b1-b304-43cf-ad28-a38d4e8c3dfc")
 		(effects
 			(font
 				(size 1.27 1.27)
@@ -48,7 +48,7 @@
 		(unlocked yes)
 		(layer "F.Fab")
 		(hide yes)
-		(uuid "846ec767-c4b6-41ed-9334-0f8af9839848")
+		(uuid "1dd6be24-48c7-460d-9080-5da036b7d723")
 		(effects
 			(font
 				(size 1.27 1.27)
@@ -56,6 +56,7 @@
 			)
 		)
 	)
+	(attr smd)
 	(duplicate_pad_numbers_are_jumpers no)
 	(fp_line
 		(start -3.675 -2.775)
@@ -65,7 +66,7 @@
 			(type solid)
 		)
 		(layer "F.SilkS")
-		(uuid "9dd65a26-6e80-4489-9373-2f8c50afca0a")
+		(uuid "e1edaad4-7224-484e-aae4-6d3cf8101fc1")
 	)
 	(fp_line
 		(start -3.675 1.775)
@@ -75,7 +76,7 @@
 			(type solid)
 		)
 		(layer "F.SilkS")
-		(uuid "eb9b6072-d8ec-4074-8930-3d655d7d94f8")
+		(uuid "9fcd032c-3280-4f20-8f63-a92c5ee13164")
 	)
 	(fp_line
 		(start -3.675 2.775)
@@ -85,7 +86,7 @@
 			(type solid)
 		)
 		(layer "F.SilkS")
-		(uuid "221fcb5e-e79a-429a-86cd-29515427e3aa")
+		(uuid "77cf3844-1f85-449f-8c95-882658465c0f")
 	)
 	(fp_line
 		(start -2.675 -2.775)
@@ -95,7 +96,7 @@
 			(type solid)
 		)
 		(layer "F.SilkS")
-		(uuid "d93162dd-36e2-40a4-ab00-5483cca7408e")
+		(uuid "9e1ca155-eeef-4698-b731-a4c26fea91a2")
 	)
 	(fp_line
 		(start 2.675 -2.775)
@@ -105,7 +106,7 @@
 			(type solid)
 		)
 		(layer "F.SilkS")
-		(uuid "f46cbb81-3a09-49f8-b2a6-bda5e57cded0")
+		(uuid "22a3461b-f102-400a-b467-16b8a23bc2ad")
 	)
 	(fp_line
 		(start 2.675 2.775)
@@ -115,7 +116,7 @@
 			(type solid)
 		)
 		(layer "F.SilkS")
-		(uuid "169e6361-50da-44e1-971f-baed8b9946b9")
+		(uuid "b5326772-f535-4cd3-aa10-0a8ea5e9047b")
 	)
 	(fp_line
 		(start 3.675 -1.775)
@@ -125,7 +126,7 @@
 			(type solid)
 		)
 		(layer "F.SilkS")
-		(uuid "c129c65c-00ac-4d66-8c75-627733744ae5")
+		(uuid "7e9ae75e-853c-4d88-a72b-bd218ade509a")
 	)
 	(fp_line
 		(start 3.675 2.775)
@@ -135,18 +136,18 @@
 			(type solid)
 		)
 		(layer "F.SilkS")
-		(uuid "583790a6-83fe-44fd-911d-a73a9775e46d")
+		(uuid "a6dd8c59-319b-4686-9261-74ebc96bcc23")
 	)
 	(fp_circle
-		(center -2.235839 2.951522)
-		(end -2.335839 2.951522)
+		(center -2.25 3)
+		(end -2.1 3)
 		(stroke
-			(width 0.2)
+			(width 0.3)
 			(type solid)
 		)
 		(fill yes)
 		(layer "F.SilkS")
-		(uuid "99eaa2bf-8fe4-41d2-a5a5-604499db5999")
+		(uuid "ab4b5076-1d76-4b6e-878b-6e30528c15bc")
 	)
 	(fp_rect
 		(start -3.675 -2.775)
@@ -157,7 +158,7 @@
 		)
 		(fill no)
 		(layer "F.CrtYd")
-		(uuid "3cbc165e-b1f9-4f01-b129-68f8c1811a9c")
+		(uuid "2e34d15f-52b2-4647-bcbd-9a73a8f38802")
 	)
 	(fp_rect
 		(start -3.475 -2.575)
@@ -168,7 +169,7 @@
 		)
 		(fill no)
 		(layer "F.Fab")
-		(uuid "9d70f412-7b0b-45ce-ac52-495d85dac898")
+		(uuid "25cbe8a8-4602-447e-a4c2-a15799e73b4a")
 	)
 	(pad "1" smd rect
 		(at -2.25 2.025)
@@ -176,7 +177,7 @@
 		(layers "F.Cu" "F.Mask" "F.Paste")
 		(solder_paste_margin -0.025)
 		(thermal_bridge_angle 0)
-		(uuid "e14288a9-f228-4b07-8e1a-11e4ea47ed92")
+		(uuid "4cd3504a-8ebf-47e9-8634-90812dea547b")
 	)
 	(pad "2" smd rect
 		(at -1.8 2.025)
@@ -184,7 +185,7 @@
 		(layers "F.Cu" "F.Mask" "F.Paste")
 		(solder_paste_margin -0.025)
 		(thermal_bridge_angle 0)
-		(uuid "83e40419-c083-430d-b2b2-05d4188c477c")
+		(uuid "36562f8a-77ba-44c4-a644-a65bd952db8a")
 	)
 	(pad "3" smd rect
 		(at -1.35 2.025)
@@ -192,7 +193,7 @@
 		(layers "F.Cu" "F.Mask" "F.Paste")
 		(solder_paste_margin -0.025)
 		(thermal_bridge_angle 0)
-		(uuid "20c64c71-d27d-47a7-9d67-124b19f70bcd")
+		(uuid "c3971fcc-cdf2-4cf3-92dc-06f3526a25b2")
 	)
 	(pad "4" smd rect
 		(at -0.9 2.025)
@@ -200,7 +201,7 @@
 		(layers "F.Cu" "F.Mask" "F.Paste")
 		(solder_paste_margin -0.025)
 		(thermal_bridge_angle 0)
-		(uuid "53e52143-4f60-4eb5-8281-0ea1cc10a0ca")
+		(uuid "33187a86-0285-4489-a0b0-7d42ee8ed7f8")
 	)
 	(pad "5" smd rect
 		(at -0.45 2.025)
@@ -208,7 +209,7 @@
 		(layers "F.Cu" "F.Mask" "F.Paste")
 		(solder_paste_margin -0.025)
 		(thermal_bridge_angle 0)
-		(uuid "d00747e6-54c5-4308-901b-3b444e94b65a")
+		(uuid "eceabdc1-959c-4c99-bcea-327b78b33d9d")
 	)
 	(pad "6" smd rect
 		(at 0 2.025)
@@ -216,7 +217,7 @@
 		(layers "F.Cu" "F.Mask" "F.Paste")
 		(solder_paste_margin -0.025)
 		(thermal_bridge_angle 0)
-		(uuid "bd7c8ace-c083-4f50-acc8-219f98e80a77")
+		(uuid "e06472cc-8f3b-4ae0-b697-910b638f59cc")
 	)
 	(pad "7" smd rect
 		(at 0.45 2.025)
@@ -224,7 +225,7 @@
 		(layers "F.Cu" "F.Mask" "F.Paste")
 		(solder_paste_margin -0.025)
 		(thermal_bridge_angle 0)
-		(uuid "f7b83234-9f80-4f41-b83d-d937495f55a4")
+		(uuid "2a500725-82a9-4551-8c8a-5ab365e50e26")
 	)
 	(pad "8" smd rect
 		(at 0.9 2.025)
@@ -232,7 +233,7 @@
 		(layers "F.Cu" "F.Mask" "F.Paste")
 		(solder_paste_margin -0.025)
 		(thermal_bridge_angle 0)
-		(uuid "17c69775-6cba-4d92-8489-9fd4b933217d")
+		(uuid "7a78aaa7-ee05-4091-857e-33cd5627d5aa")
 	)
 	(pad "9" smd rect
 		(at 1.35 2.025)
@@ -240,7 +241,7 @@
 		(layers "F.Cu" "F.Mask" "F.Paste")
 		(solder_paste_margin -0.025)
 		(thermal_bridge_angle 0)
-		(uuid "d8026ab4-347b-4b1e-9fb2-15c4a291df10")
+		(uuid "befefdd8-3800-468e-a7be-136f53ed9303")
 	)
 	(pad "10" smd rect
 		(at 1.8 2.025)
@@ -248,7 +249,7 @@
 		(layers "F.Cu" "F.Mask" "F.Paste")
 		(solder_paste_margin -0.025)
 		(thermal_bridge_angle 0)
-		(uuid "8c2366a1-5de7-4784-8947-826c277f9815")
+		(uuid "5bbf30a2-9c11-4362-8f66-9a90c81b28e3")
 	)
 	(pad "11" smd rect
 		(at 2.25 2.025)
@@ -256,7 +257,7 @@
 		(layers "F.Cu" "F.Mask" "F.Paste")
 		(solder_paste_margin -0.025)
 		(thermal_bridge_angle 0)
-		(uuid "d6dcdb39-28f0-4fc6-be8b-9bf466135777")
+		(uuid "8d465888-01fe-4020-9904-5f832215dc88")
 	)
 	(pad "12" smd rect
 		(at 2.925 2.0875)
@@ -264,7 +265,7 @@
 		(layers "F.Cu" "F.Mask" "F.Paste")
 		(solder_paste_margin -0.025)
 		(thermal_bridge_angle 0)
-		(uuid "1cc4064d-3ecb-4dca-8558-30a41e6a45fc")
+		(uuid "30144d93-c745-4091-913a-22e6aeec33be")
 	)
 	(pad "13" smd rect
 		(at 2.925 1.575 90)
@@ -272,7 +273,7 @@
 		(layers "F.Cu" "F.Mask" "F.Paste")
 		(solder_paste_margin -0.025)
 		(thermal_bridge_angle 0)
-		(uuid "0858ad8d-95fc-42e1-8e4c-c3bd07b3c58c")
+		(uuid "64799328-f356-43d2-acad-b09f26545714")
 	)
 	(pad "14" smd rect
 		(at 2.925 1.125 90)
@@ -280,7 +281,7 @@
 		(layers "F.Cu" "F.Mask" "F.Paste")
 		(solder_paste_margin -0.025)
 		(thermal_bridge_angle 0)
-		(uuid "2c594ae0-d295-4e00-8c5d-37ba1963c5e2")
+		(uuid "01075f5f-07d9-45cd-ae06-ce74f5a552d6")
 	)
 	(pad "15" smd rect
 		(at 2.925 0.675 90)
@@ -288,7 +289,7 @@
 		(layers "F.Cu" "F.Mask" "F.Paste")
 		(solder_paste_margin -0.025)
 		(thermal_bridge_angle 0)
-		(uuid "e60889ac-a430-436b-99f6-a75a88d0e06f")
+		(uuid "68e5ab9b-ef9e-4bdd-aa91-f7297e5bf6d1")
 	)
 	(pad "16" smd rect
 		(at 2.925 0.225 90)
@@ -296,7 +297,7 @@
 		(layers "F.Cu" "F.Mask" "F.Paste")
 		(solder_paste_margin -0.025)
 		(thermal_bridge_angle 0)
-		(uuid "2badd036-5b37-4dad-91bf-c8b7eb0b837e")
+		(uuid "578b82b5-1c74-45bc-8fdd-2357131026f6")
 	)
 	(pad "17" smd rect
 		(at 2.925 -0.225 90)
@@ -304,7 +305,7 @@
 		(layers "F.Cu" "F.Mask" "F.Paste")
 		(solder_paste_margin -0.025)
 		(thermal_bridge_angle 0)
-		(uuid "53f2c771-c064-4aa3-b392-839d16c08aca")
+		(uuid "6df1e1ea-b8fb-4a63-a9da-37e579d738c2")
 	)
 	(pad "18" smd rect
 		(at 2.925 -0.675 90)
@@ -312,7 +313,7 @@
 		(layers "F.Cu" "F.Mask" "F.Paste")
 		(solder_paste_margin -0.025)
 		(thermal_bridge_angle 0)
-		(uuid "43f8323c-2193-4241-b36f-b5fbf8477fb4")
+		(uuid "a5cf8e08-70f1-49e5-a798-122b8c6f97a1")
 	)
 	(pad "19" smd rect
 		(at 2.925 -1.125 90)
@@ -320,7 +321,7 @@
 		(layers "F.Cu" "F.Mask" "F.Paste")
 		(solder_paste_margin -0.025)
 		(thermal_bridge_angle 0)
-		(uuid "d33614c7-5ecc-4a8a-9b91-5ecac1a7e14a")
+		(uuid "871a7b9d-9b93-4e1b-8e3e-5f6444e1c460")
 	)
 	(pad "20" smd rect
 		(at 2.925 -1.575 90)
@@ -328,7 +329,7 @@
 		(layers "F.Cu" "F.Mask" "F.Paste")
 		(solder_paste_margin -0.025)
 		(thermal_bridge_angle 0)
-		(uuid "1d4ac9d6-cb7d-44da-8aaa-15605c7f08ca")
+		(uuid "4bee736a-ccd7-4e5d-96b8-36e8e9585b98")
 	)
 	(pad "21" smd rect
 		(at 2.925 -2.0875)
@@ -336,7 +337,7 @@
 		(layers "F.Cu" "F.Mask" "F.Paste")
 		(solder_paste_margin -0.025)
 		(thermal_bridge_angle 0)
-		(uuid "3f4f96e1-05f8-451b-ae9e-b851d6abdec2")
+		(uuid "df20b92b-612b-49ca-b207-4c8998e1f0e4")
 	)
 	(pad "22" smd rect
 		(at 2.25 -2.025)
@@ -344,7 +345,7 @@
 		(layers "F.Cu" "F.Mask" "F.Paste")
 		(solder_paste_margin -0.025)
 		(thermal_bridge_angle 0)
-		(uuid "2dd1759e-8e97-4957-a510-83ca05c9b9ab")
+		(uuid "bf205069-4035-4660-a2de-2e51e36f86d1")
 	)
 	(pad "23" smd rect
 		(at 1.8 -2.025)
@@ -352,7 +353,7 @@
 		(layers "F.Cu" "F.Mask" "F.Paste")
 		(solder_paste_margin -0.025)
 		(thermal_bridge_angle 0)
-		(uuid "16f15bbe-ff47-4d4f-842f-d65bdae6d693")
+		(uuid "e5b792ed-2cce-471d-80ce-c29554ee3014")
 	)
 	(pad "24" smd rect
 		(at 1.35 -2.025)
@@ -360,7 +361,7 @@
 		(layers "F.Cu" "F.Mask" "F.Paste")
 		(solder_paste_margin -0.025)
 		(thermal_bridge_angle 0)
-		(uuid "17c4b80b-8060-454b-aa9b-4924528e2271")
+		(uuid "8b2ac92a-65e3-431f-9b2a-bf7ab4e443b7")
 	)
 	(pad "25" smd rect
 		(at 0.9 -2.025)
@@ -368,7 +369,7 @@
 		(layers "F.Cu" "F.Mask" "F.Paste")
 		(solder_paste_margin -0.025)
 		(thermal_bridge_angle 0)
-		(uuid "69ae0084-e849-41b8-a8c8-ac953ac46e2e")
+		(uuid "2b725cca-ff07-4e6c-a578-34cbc022ca7f")
 	)
 	(pad "26" smd rect
 		(at 0.45 -2.025)
@@ -376,7 +377,7 @@
 		(layers "F.Cu" "F.Mask" "F.Paste")
 		(solder_paste_margin -0.025)
 		(thermal_bridge_angle 0)
-		(uuid "ab657497-eb79-459b-8432-202bc3608f93")
+		(uuid "95229ff3-6ca7-4482-b775-b316acbb0426")
 	)
 	(pad "27" smd rect
 		(at 0 -2.025)
@@ -384,7 +385,7 @@
 		(layers "F.Cu" "F.Mask" "F.Paste")
 		(solder_paste_margin -0.025)
 		(thermal_bridge_angle 0)
-		(uuid "a1533bc8-70b6-498b-b0ca-1e113c21cddf")
+		(uuid "d1c1e4b3-52f0-46f1-9b19-73b43ca472c5")
 	)
 	(pad "28" smd rect
 		(at -0.45 -2.025)
@@ -392,7 +393,7 @@
 		(layers "F.Cu" "F.Mask" "F.Paste")
 		(solder_paste_margin -0.025)
 		(thermal_bridge_angle 0)
-		(uuid "b80a25a6-c981-40bf-b4c6-3012451b33a9")
+		(uuid "9a8c2700-ba43-4365-b177-7ed25f73ee1d")
 	)
 	(pad "29" smd rect
 		(at -0.9 -2.025)
@@ -400,7 +401,7 @@
 		(layers "F.Cu" "F.Mask" "F.Paste")
 		(solder_paste_margin -0.025)
 		(thermal_bridge_angle 0)
-		(uuid "a7292844-70dc-4b64-8222-439797190c57")
+		(uuid "af0997f3-0502-4406-aae5-68b17064fd53")
 	)
 	(pad "30" smd rect
 		(at -1.35 -2.025)
@@ -408,7 +409,7 @@
 		(layers "F.Cu" "F.Mask" "F.Paste")
 		(solder_paste_margin -0.025)
 		(thermal_bridge_angle 0)
-		(uuid "5a041748-9a07-4e91-b47c-89ca3478c92d")
+		(uuid "8230a63c-e1b9-41e1-a2ac-02cb6ffdf07c")
 	)
 	(pad "31" smd rect
 		(at -1.8 -2.025)
@@ -416,7 +417,7 @@
 		(layers "F.Cu" "F.Mask" "F.Paste")
 		(solder_paste_margin -0.025)
 		(thermal_bridge_angle 0)
-		(uuid "0d634ec4-54d8-422e-9d22-e6fbde2def14")
+		(uuid "8e6ad653-bff5-461c-b128-928a8fbb04cd")
 	)
 	(pad "32" smd rect
 		(at -2.25 -2.025)
@@ -424,7 +425,7 @@
 		(layers "F.Cu" "F.Mask" "F.Paste")
 		(solder_paste_margin -0.025)
 		(thermal_bridge_angle 0)
-		(uuid "54e007e6-7f5f-41cb-affa-2b7739ea0e8a")
+		(uuid "887870cc-da19-4810-97ec-af9eea80c2a5")
 	)
 	(pad "33" smd rect
 		(at -2.925 -2.0875)
@@ -432,7 +433,7 @@
 		(layers "F.Cu" "F.Mask" "F.Paste")
 		(solder_paste_margin -0.025)
 		(thermal_bridge_angle 0)
-		(uuid "e597ce2b-a9df-482f-b23b-411dfee4bc4b")
+		(uuid "15759014-6d5c-4180-8d3e-62ee72cd4563")
 	)
 	(pad "34" smd rect
 		(at -2.925 -1.575 90)
@@ -440,7 +441,7 @@
 		(layers "F.Cu" "F.Mask" "F.Paste")
 		(solder_paste_margin -0.025)
 		(thermal_bridge_angle 0)
-		(uuid "c5e27ae7-8408-433a-bc34-bf05242a9a03")
+		(uuid "9a6bde05-8d04-40ed-82e6-fb84afad2408")
 	)
 	(pad "35" smd rect
 		(at -2.925 -1.125 90)
@@ -448,7 +449,7 @@
 		(layers "F.Cu" "F.Mask" "F.Paste")
 		(solder_paste_margin -0.025)
 		(thermal_bridge_angle 0)
-		(uuid "b079cd1e-98bc-4a2a-9783-1af8d7d52836")
+		(uuid "fa36117c-2771-4b9f-b4d8-5d0ccf0fa72d")
 	)
 	(pad "36" smd rect
 		(at -2.925 -0.675 90)
@@ -456,7 +457,7 @@
 		(layers "F.Cu" "F.Mask" "F.Paste")
 		(solder_paste_margin -0.025)
 		(thermal_bridge_angle 0)
-		(uuid "e39511b6-7302-4207-8dd4-0eece1eb8656")
+		(uuid "262eb3b3-6984-4787-bf92-50418a71313d")
 	)
 	(pad "37" smd rect
 		(at -2.925 -0.225 90)
@@ -464,7 +465,7 @@
 		(layers "F.Cu" "F.Mask" "F.Paste")
 		(solder_paste_margin -0.025)
 		(thermal_bridge_angle 0)
-		(uuid "9aa5d38e-d91d-4477-8f3d-17f9567e36e3")
+		(uuid "09eb3606-994f-43e6-8cc0-12580f382115")
 	)
 	(pad "38" smd rect
 		(at -2.925 0.225 90)
@@ -472,7 +473,7 @@
 		(layers "F.Cu" "F.Mask" "F.Paste")
 		(solder_paste_margin -0.025)
 		(thermal_bridge_angle 0)
-		(uuid "0eeda752-e80c-4234-b854-40c959f42c24")
+		(uuid "d2a0d698-c1f2-4863-8fcb-c9e801c296c8")
 	)
 	(pad "39" smd rect
 		(at -2.925 0.675 90)
@@ -480,7 +481,7 @@
 		(layers "F.Cu" "F.Mask" "F.Paste")
 		(solder_paste_margin -0.025)
 		(thermal_bridge_angle 0)
-		(uuid "659329f0-b40f-4582-95e9-b89f895078c5")
+		(uuid "7b372e40-0ed4-43bb-abe5-b2a15ab62c4d")
 	)
 	(pad "40" smd rect
 		(at -2.925 1.125 90)
@@ -488,7 +489,7 @@
 		(layers "F.Cu" "F.Mask" "F.Paste")
 		(solder_paste_margin -0.025)
 		(thermal_bridge_angle 0)
-		(uuid "e7a58211-4f90-4794-a0f6-6aa09a86a8dd")
+		(uuid "b8e51f05-6472-49e6-95fe-d7f5c2e63a62")
 	)
 	(pad "41" smd rect
 		(at -2.925 1.575 90)
@@ -496,7 +497,7 @@
 		(layers "F.Cu" "F.Mask" "F.Paste")
 		(solder_paste_margin -0.025)
 		(thermal_bridge_angle 0)
-		(uuid "374f2199-7aab-4f5f-a093-000754fa4a2d")
+		(uuid "28f2b700-b822-46e9-a8b9-1e8b6809e94e")
 	)
 	(pad "42" smd rect
 		(at -2.925 2.0875)
@@ -504,7 +505,7 @@
 		(layers "F.Cu" "F.Mask" "F.Paste")
 		(solder_paste_margin -0.025)
 		(thermal_bridge_angle 0)
-		(uuid "caf41597-a769-4935-82ff-c481d900cd54")
+		(uuid "73256240-4075-4d63-8c19-bbe4b011e85c")
 	)
 	(pad "43" smd roundrect
 		(at -1 0.75)
@@ -515,7 +516,7 @@
 		(chamfer bottom_left)
 		(solder_paste_margin -0.1)
 		(thermal_bridge_angle 0)
-		(uuid "0c244a08-50e4-4ddd-8eb6-48a8a00e1e96")
+		(uuid "a82fa997-f3e0-4920-81b9-79c61aa8e732")
 	)
 	(pad "44" smd rect
 		(at 1 0.75)
@@ -523,7 +524,7 @@
 		(layers "F.Cu" "F.Mask" "F.Paste")
 		(solder_paste_margin -0.1)
 		(thermal_bridge_angle 0)
-		(uuid "733157fe-14f8-41d8-9152-ac46555e73ca")
+		(uuid "6ad0f63e-f853-401d-95b6-3bad868ca12e")
 	)
 	(pad "45" smd rect
 		(at -1 -0.75)
@@ -531,7 +532,7 @@
 		(layers "F.Cu" "F.Mask" "F.Paste")
 		(solder_paste_margin -0.1)
 		(thermal_bridge_angle 0)
-		(uuid "20ae39b8-e660-4ccf-9f03-2b22826e3f09")
+		(uuid "fd800956-fdc5-474f-bc43-ae7f69b56b50")
 	)
 	(pad "46" smd rect
 		(at 1 -0.75)
@@ -539,10 +540,10 @@
 		(layers "F.Cu" "F.Mask" "F.Paste")
 		(solder_paste_margin -0.1)
 		(thermal_bridge_angle 0)
-		(uuid "8855c468-e224-4786-8433-9c2d307b1caa")
+		(uuid "36f47342-0f51-4612-92a9-7c2e901ca42d")
 	)
 	(embedded_fonts no)
-	(model "${SPARKFUN_KICAD_LIBRARY}/3dmodels/RF.3dshapes/LBEE5KL1YN.STEP"
+	(model "${SPARKFUN_KICAD_LIBRARY}/3dmodels/RF.3dshapes/LBEE5KL1YN.step"
 		(offset
 			(xyz 0 0 0)
 		)

--- a/symbols/SparkFun-RF.kicad_sym
+++ b/symbols/SparkFun-RF.kicad_sym
@@ -10386,7 +10386,7 @@
 					)
 				)
 			)
-			(pin output line
+			(pin power_out line
 				(at -22.86 17.78 0)
 				(length 2.54)
 				(name "SR_VLX"


### PR DESCRIPTION
- Change 3D model from .STEP to .step to match the actual file name
- Correct SR_VLX pin to be of type Power ouput
- Change component type to SMD (otherwise it's listed as a virtual model in the 3D viewer)
- Increase pin 1 indicator size

KiCad also decided to change a bunch of UUID values. Not sure if that matters? Would it be safe to omit those changes for clarity of PRs?